### PR TITLE
Fix MailerLite webhook dedupe and logging

### DIFF
--- a/__tests__/mailerlite-webhook.spec.ts
+++ b/__tests__/mailerlite-webhook.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'vitest';
+import { buildExternalId, type MailerLiteWebhookPayload } from '../pages/api/mailerlite/webhook.ts';
+
+describe('MailerLite webhook external id builder', () => {
+  test('uses provided identifiers when present', () => {
+    const payload: MailerLiteWebhookPayload = {
+      event: 'campaign.sent',
+      data: {
+        event_id: 'evt-123',
+        subscriber_id: 'sub-1',
+      },
+    };
+
+    const id = buildExternalId(payload, 'person@example.com', payload.event, '2024-01-01T00:00:00.000Z');
+
+    expect(id).toBe('evt-123');
+  });
+
+  test('falls back to composite id when only subscriber information is available', () => {
+    const payload: MailerLiteWebhookPayload = {
+      event: 'automation.email.sent',
+      data: {
+        subscriber_id: 123,
+        subscriber_email: 'welcome@example.com',
+      },
+    };
+
+    const id = buildExternalId(payload, undefined, payload.event, '2024-01-01T00:00:01.000Z');
+
+    expect(id).toContain('automation.email.sent');
+    expect(id).toContain('123');
+    expect(id).toContain('welcome@example.com');
+  });
+
+  test('generates distinct ids for repeated subscriber automation events', () => {
+    const payload: MailerLiteWebhookPayload = {
+      event: 'automation.email.sent',
+      data: {
+        subscriber: { id: 'abc' },
+      },
+    };
+
+    const first = buildExternalId(payload, 'person@example.com', payload.event, '2024-01-01T00:00:01.000Z');
+    const second = buildExternalId(payload, 'person@example.com', payload.event, '2024-01-01T00:00:02.000Z');
+
+    expect(first).not.toBe(second);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure MailerLite webhook builds composite external IDs instead of reusing the subscriber identifier when no event-specific id is provided
- expose a module-load log for the MailerLite route and document how to confirm it in Vercel logs
- cover the new external-id builder behaviour with vitest cases for provided ids, subscriber fallbacks, and repeated events

## Testing
- npm test *(fails: vitest not found in environment — dependencies cannot be installed in this sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e3dab5473483328d4b9830a30706e7