### PR TITLE
Handle alternate MailerLite webhook signature headers

### DIFF
--- a/__tests__/mailerlite-webhook.spec.ts
+++ b/__tests__/mailerlite-webhook.spec.ts
@@ -1,5 +1,17 @@
-import { describe, expect, test } from 'vitest';
-import { buildExternalId, type MailerLiteWebhookPayload } from '../pages/api/mailerlite/webhook.ts';
+import crypto from 'node:crypto';
+import { beforeAll, describe, expect, test, vi } from 'vitest';
+import type { MailerLiteWebhookPayload } from '../pages/api/mailerlite/webhook.ts';
+
+type WebhookModule = typeof import('../pages/api/mailerlite/webhook.ts');
+
+let buildExternalId: WebhookModule['buildExternalId'];
+let verifySignature: WebhookModule['verifySignature'];
+
+beforeAll(async () => {
+  process.env.MAILERLITE_WEBHOOK_SECRET = 'test-secret';
+  vi.resetModules();
+  ({ buildExternalId, verifySignature } = await import('../pages/api/mailerlite/webhook.ts'));
+});
 
 describe('MailerLite webhook external id builder', () => {
   test('uses provided identifiers when present', () => {
@@ -44,5 +56,19 @@ describe('MailerLite webhook external id builder', () => {
     const second = buildExternalId(payload, 'person@example.com', payload.event, '2024-01-01T00:00:02.000Z');
 
     expect(first).not.toBe(second);
+  });
+});
+
+describe('MailerLite webhook signature verification', () => {
+  test('accepts the Signature header alias', () => {
+    const payload = { event: 'campaign.sent' } satisfies MailerLiteWebhookPayload;
+    const raw = Buffer.from(JSON.stringify(payload));
+    const digest = crypto.createHmac('sha256', 'test-secret').update(raw).digest('hex');
+
+    const valid = verifySignature(raw, {
+      signature: `sha256=${digest}`,
+    });
+
+    expect(valid).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- update MailerLite webhook signature verification to accept multiple header aliases and expose richer failure logging
- include all supported signature headers when verifying requests in the API handler
- cover the Signature header path with a new unit test

## Testing
- ⚠️ `npm test` *(fails: npm registry access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e42779820c8332b2f957b55f6f6b03