### PR TITLE
Handle MailerLite top-level payload schema

### DIFF
--- a/__tests__/mailerlite-webhook.spec.ts
+++ b/__tests__/mailerlite-webhook.spec.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from 'vitest';
-import { buildExternalId, type MailerLiteWebhookPayload } from '../pages/api/mailerlite/webhook.ts';
+import {
+  buildExternalId,
+  extractCampaignDetails,
+  extractEmail,
+  extractSubscriberId,
+  type MailerLiteWebhookPayload,
+} from '../pages/api/mailerlite/webhook.ts';
 
 describe('MailerLite webhook external id builder', () => {
   test('uses provided identifiers when present', () => {
@@ -44,5 +50,63 @@ describe('MailerLite webhook external id builder', () => {
     const second = buildExternalId(payload, 'person@example.com', payload.event, '2024-01-01T00:00:02.000Z');
 
     expect(first).not.toBe(second);
+  });
+
+  test('generates stable composite ids when only top-level subscriber information is provided', () => {
+    const payload: MailerLiteWebhookPayload = {
+      event: 'campaign.opened',
+      subscriber: {
+        id: 'top-level-1',
+        email: 'top@example.com',
+      },
+    };
+
+    const id = buildExternalId(payload, extractEmail(payload), payload.event, '2024-01-01T00:00:03.000Z');
+
+    expect(id).toContain('campaign.opened');
+    expect(id).toContain('top-level-1');
+    expect(id).toContain('top@example.com');
+  });
+});
+
+describe('MailerLite webhook extraction helpers', () => {
+  test('extractEmail uses top-level subscriber email when data is missing', () => {
+    const payload: MailerLiteWebhookPayload = {
+      event: 'campaign.sent',
+      subscriber: {
+        email: 'root-subscriber@example.com',
+      },
+    };
+
+    expect(extractEmail(payload)).toBe('root-subscriber@example.com');
+  });
+
+  test('extractSubscriberId falls back to top-level subscriber identifiers', () => {
+    const payload: MailerLiteWebhookPayload = {
+      event: 'campaign.sent',
+      subscriber_id: 'subscriber-007',
+      subscriber: {
+        id: 'subscriber-object',
+      },
+    };
+
+    expect(extractSubscriberId(payload)).toBe('subscriber-007');
+  });
+
+  test('extractCampaignDetails reads from top-level campaign fields', () => {
+    const payload: MailerLiteWebhookPayload = {
+      event: 'campaign.sent',
+      campaign: {
+        id: 'cmp-root-123',
+        name: 'Top Level Launch',
+        subject: 'New release',
+      },
+    };
+
+    const { campaignId, campaignName, subject } = extractCampaignDetails(payload);
+
+    expect(campaignId).toBe('cmp-root-123');
+    expect(campaignName).toBe('Top Level Launch');
+    expect(subject).toBe('New release');
   });
 });


### PR DESCRIPTION
## Summary
- update MailerLite webhook helper functions to read subscriber and campaign data from both legacy `data` and new top-level payload properties
- adjust the external ID builder to include top-level subscriber identifiers and email fallbacks for consistency across payload formats
- expand the vitest suite with fixtures covering the top-level MailerLite webhook schema to guard future changes

## Testing
- npm test *(fails: vitest binary unavailable because dependencies could not be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4277c44c483328b25694eb2e1a666